### PR TITLE
Fix for ACCOUNT_UPDATE tag deprecation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,4 @@ CLAUDE.md
 .claude/settings.local.json
 .cursor
 .env.real
+.env.serve

--- a/app/services/facebook/send_on_facebook_service.rb
+++ b/app/services/facebook/send_on_facebook_service.rb
@@ -40,12 +40,11 @@ class Facebook::SendOnFacebookService < Base::SendOnChannelService
   end
 
   def fb_text_message_params
-    {
+    params = {
       recipient: { id: contact.get_source_id(inbox.id) },
       message: { text: message.content },
-      messaging_type: 'MESSAGE_TAG',
-      tag: 'ACCOUNT_UPDATE'
     }
+    merge_human_agent_tag(params)
   end
 
   def external_error(response)
@@ -58,7 +57,7 @@ class Facebook::SendOnFacebookService < Base::SendOnChannelService
 
   def fb_attachment_message_params
     attachment = message.attachments.first
-    {
+    params = {
       recipient: { id: contact.get_source_id(inbox.id) },
       message: {
         attachment: {
@@ -68,9 +67,8 @@ class Facebook::SendOnFacebookService < Base::SendOnChannelService
           }
         }
       },
-      messaging_type: 'MESSAGE_TAG',
-      tag: 'ACCOUNT_UPDATE'
     }
+    merge_human_agent_tag(params)
   end
 
   def attachment_type(attachment)
@@ -97,5 +95,15 @@ class Facebook::SendOnFacebookService < Base::SendOnChannelService
     return unless exception.to_s.include?('The session has been invalidated') || exception.to_s.include?('Error validating access token')
 
     channel.authorization_error!
+  end
+
+  def merge_human_agent_tag(params)
+    global_config = GlobalConfig.get('ENABLE_MESSENGER_CHANNEL_HUMAN_AGENT')
+
+    return params unless global_config['ENABLE_MESSENGER_CHANNEL_HUMAN_AGENT']
+
+    params[:messaging_type] = 'MESSAGE_TAG'
+    params[:tag] = 'HUMAN_AGENT'
+    params
   end
 end


### PR DESCRIPTION
Replaced the deprecated `ACCOUNT_UPDATE` with `HUMAN_AGENT` tag to extend message window from 24 hrs to 7 days.